### PR TITLE
Implement derive macro for RegisteredEvent

### DIFF
--- a/cqrs-codegen/src/event/mod.rs
+++ b/cqrs-codegen/src/event/mod.rs
@@ -78,33 +78,6 @@ fn assert_all_enum_variants_have_single_field(
     Ok(())
 }
 
-/// Renders implementation of `trait_path` trait with given `where_clause`
-/// as a `method` with given `body`.
-///
-/// Expects that all variants of `structure` contain exactly one field.
-/// Returns error otherwise.
-///
-/// `trait_name` is only used to generate error message.
-pub fn render_enum(
-    structure: &mut Structure,
-    trait_path: TokenStream,
-    method: TokenStream,
-    method_return_type: TokenStream,
-    body: TokenStream,
-    where_clause: Option<syn::WhereClause>,
-) -> Result<TokenStream> {
-    Ok(structure.gen_impl(quote! {
-        #[automatically_derived]
-        gen impl #trait_path for @Self #where_clause {
-            fn #method(&self) -> #method_return_type {
-                match *self {
-                    #body
-                }
-            }
-        }
-    }))
-}
-
 /// Renders implementation of a `trait_path` trait as a `method` that proxies
 /// call to it's variants.
 ///

--- a/cqrs-codegen/src/event/mod.rs
+++ b/cqrs-codegen/src/event/mod.rs
@@ -91,20 +91,19 @@ pub fn render_enum(
     method: TokenStream,
     method_return_type: TokenStream,
     body: TokenStream,
-    where_clause: Option<syn::WhereClause>
+    where_clause: Option<syn::WhereClause>,
 ) -> Result<TokenStream> {
     Ok(structure.gen_impl(quote! {
-            #[automatically_derived]
-            gen impl #trait_path for @Self #where_clause {
-                fn #method(&self) -> #method_return_type {
-                    match *self {
-                        #body
-                    }
+        #[automatically_derived]
+        gen impl #trait_path for @Self #where_clause {
+            fn #method(&self) -> #method_return_type {
+                match *self {
+                    #body
                 }
             }
-        }))
+        }
+    }))
 }
-
 
 /// Renders implementation of a `trait_path` trait as a `method` that proxies
 /// call to it's variants.

--- a/cqrs-codegen/src/event/registered_event.rs
+++ b/cqrs-codegen/src/event/registered_event.rs
@@ -30,8 +30,6 @@ fn derive_struct(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
 /// Implements [`crate::derive_registered_event`] macro expansion for enums
 /// via [`synstructure`].
 fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
-    util::assert_attr_does_not_exist(&input.attrs, super::ATTR_NAME)?;
-
     let mut structure = Structure::try_new(&input)?;
 
     super::render_enum_proxy_method_calls(

--- a/cqrs-codegen/src/event/registered_event.rs
+++ b/cqrs-codegen/src/event/registered_event.rs
@@ -1,0 +1,131 @@
+//! Codegen for [`cqrs::RegisteredEvent`].
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Result;
+use synstructure::Structure;
+
+use crate::util;
+
+/// Name of the derived trait.
+const TRAIT_NAME: &str = "RegisteredEvent";
+
+/// Implements [`crate::derive_registered_event`] macro expansion.
+pub fn derive(input: syn::DeriveInput) -> Result<TokenStream> {
+    util::derive(input, TRAIT_NAME, derive_struct, derive_enum)
+}
+
+/// Implements [`crate::derive_registered_event`] macro expansion for structs.
+fn derive_struct(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
+    let body = quote! {
+        #[inline(always)]
+        fn type_id(&self) -> ::core::any::TypeId {
+            ::core::any::TypeId::of::<Self>()
+        }
+    };
+
+    super::render_struct(&input, quote!(::cqrs::RegisteredEvent), body, None)
+}
+
+/// Implements [`crate::derive_registered_event`] macro expansion for enums
+/// via [`synstructure`].
+fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
+    util::assert_attr_does_not_exist(&input.attrs, super::ATTR_NAME)?;
+
+    let mut structure = Structure::try_new(&input)?;
+
+    super::assert_all_enum_variants_have_single_field(&structure, TRAIT_NAME)?;
+
+    structure.add_bounds(synstructure::AddBounds::None);
+
+    structure.bind_with(|_| synstructure::BindStyle::Move);
+    structure.binding_name(|_, _| {
+        syn::Ident::new("_", proc_macro2::Span::call_site())
+    });
+
+    let body = structure.each(|bi| {
+        let ty = &bi.ast().ty;
+        quote!(::core::any::TypeId::of::<#ty>())
+    });
+
+    let mut where_clause = None;
+
+    structure.add_trait_bounds(
+        &syn::parse2(quote!(::cqrs::Event))?,
+        &mut where_clause,
+        synstructure::AddBounds::Fields
+    );
+
+    if let Some(where_clause) = &mut where_clause {
+        for predicate in where_clause.predicates.iter_mut() {
+            match predicate {
+                syn::WherePredicate::Type(predicate) => {
+                    predicate.bounds.push(syn::parse2(quote!('static))?);
+                }
+                _ => (),
+            }
+        }
+    }
+
+    super::render_enum(
+        &mut structure,
+        quote!(::cqrs::RegisteredEvent),
+        quote!(type_id),
+        quote!(::core::any::TypeId),
+        body,
+        where_clause
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn derives_struct_impl() {
+        let input = syn::parse_quote! {
+            struct Event;
+        };
+
+        let output = quote! {
+            #[automatically_derived]
+            impl ::cqrs::RegisteredEvent for Event {
+                #[inline(always)]
+                fn type_id (&self) -> ::core::any::TypeId {
+                    ::core::any::TypeId::of::<Self>()
+                }
+            }
+        };
+
+        assert_eq!(derive(input).unwrap().to_string(), output.to_string())
+    }
+
+    #[test]
+    fn derives_enum_impl() {
+        let input = syn::parse_quote! {
+            enum Event {
+                Event1(Event1),
+                Event2 {
+                    other_event: Event2,
+                },
+            }
+        };
+
+        let output = quote! {
+            #[allow(non_upper_case_globals)]
+            const _DERIVE_cqrs_RegisteredEvent_FOR_Event: () = {
+                #[automatically_derived]
+                impl ::cqrs::RegisteredEvent for Event {
+                    fn type_id(&self) -> ::core::any::TypeId {
+                        match *self {
+                            Event::Event1(_,) => {{ ::core::any::TypeId::of::<Event1>() }}
+                            Event::Event2{other_event: _,} => {{ ::core::any::TypeId::of::<Event2>() }}
+                        }
+                    }
+                }
+            };
+        };
+
+        assert_eq!(derive(input).unwrap().to_string(), output.to_string())
+    }
+}

--- a/cqrs-codegen/src/event/registered_event.rs
+++ b/cqrs-codegen/src/event/registered_event.rs
@@ -34,44 +34,12 @@ fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
 
     let mut structure = Structure::try_new(&input)?;
 
-    super::assert_all_enum_variants_have_single_field(&structure, TRAIT_NAME)?;
-
-    structure.add_bounds(synstructure::AddBounds::None);
-
-    structure.bind_with(|_| synstructure::BindStyle::Move);
-    structure.binding_name(|_, _| syn::Ident::new("_", proc_macro2::Span::call_site()));
-
-    let body = structure.each(|bi| {
-        let ty = &bi.ast().ty;
-        quote!(::core::any::TypeId::of::<#ty>())
-    });
-
-    let mut where_clause = None;
-
-    structure.add_trait_bounds(
-        &syn::parse2(quote!(::cqrs::Event))?,
-        &mut where_clause,
-        synstructure::AddBounds::Fields,
-    );
-
-    if let Some(where_clause) = &mut where_clause {
-        for predicate in where_clause.predicates.iter_mut() {
-            match predicate {
-                syn::WherePredicate::Type(predicate) => {
-                    predicate.bounds.push(syn::parse2(quote!('static))?);
-                }
-                _ => (),
-            }
-        }
-    }
-
-    super::render_enum(
+    super::render_enum_proxy_method_calls(
         &mut structure,
+        TRAIT_NAME,
         quote!(::cqrs::RegisteredEvent),
         quote!(type_id),
         quote!(::core::any::TypeId),
-        body,
-        where_clause,
     )
 }
 
@@ -116,8 +84,8 @@ mod spec {
                 impl ::cqrs::RegisteredEvent for Event {
                     fn type_id(&self) -> ::core::any::TypeId {
                         match *self {
-                            Event::Event1(_,) => {{ ::core::any::TypeId::of::<Event1>() }}
-                            Event::Event2{other_event: _,} => {{ ::core::any::TypeId::of::<Event2>() }}
+                            Event::Event1(ref ev,) => {{ ev.type_id() }}
+                            Event::Event2{other_event: ref other_event,} => {{ other_event.type_id() }}
                         }
                     }
                 }

--- a/cqrs-codegen/src/event/registered_event.rs
+++ b/cqrs-codegen/src/event/registered_event.rs
@@ -39,9 +39,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
     structure.add_bounds(synstructure::AddBounds::None);
 
     structure.bind_with(|_| synstructure::BindStyle::Move);
-    structure.binding_name(|_, _| {
-        syn::Ident::new("_", proc_macro2::Span::call_site())
-    });
+    structure.binding_name(|_, _| syn::Ident::new("_", proc_macro2::Span::call_site()));
 
     let body = structure.each(|bi| {
         let ty = &bi.ast().ty;
@@ -53,7 +51,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
     structure.add_trait_bounds(
         &syn::parse2(quote!(::cqrs::Event))?,
         &mut where_clause,
-        synstructure::AddBounds::Fields
+        synstructure::AddBounds::Fields,
     );
 
     if let Some(where_clause) = &mut where_clause {
@@ -73,7 +71,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
         quote!(type_id),
         quote!(::core::any::TypeId),
         body,
-        where_clause
+        where_clause,
     )
 }
 

--- a/cqrs-codegen/src/event/registered_event.rs
+++ b/cqrs-codegen/src/event/registered_event.rs
@@ -76,7 +76,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
 }
 
 #[cfg(test)]
-mod test {
+mod spec {
     use super::*;
 
     #[test]

--- a/cqrs-codegen/src/lib.rs
+++ b/cqrs-codegen/src/lib.rs
@@ -52,6 +52,50 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
     expand(input, event::derive)
 }
 
+/// Derives [`cqrs::RegisteredEvent`] implementation for structs and enums.
+///
+/// # Structs
+///
+/// When deriving [`cqrs::RegisteredEvent`] for struct, the struct is treated as
+/// a single distinct event.
+///
+/// # Enums
+///
+/// When deriving [`cqrs::RegisteredEvent`] for enum, the enum is treated as
+/// a sum-type representing a set of possible events.
+///
+/// In practice this means, that [`cqrs::RegisteredEvent`] can only be derived
+/// for an enum when all variants of such enum have exactly one field (variant
+/// can be either a tuple-variant or a struct-variant).
+///
+/// Generated implementation of [`cqrs::RegisteredEvent::type_id`] would
+/// match on all variants and return [`core::any::TypeId`] of each variant's
+/// field (__without proxying call to it__, so fields don't have to implement
+/// [`cqrs::RegisteredEvent`] themself).
+///
+/// # Examples
+/// ```
+/// # use cqrs_codegen::{Event, RegisteredEvent};
+/// #
+/// #[derive(Event, RegisteredEvent)]
+/// #[event(type = "user.created")]
+/// struct UserCreated;
+///
+/// #[derive(Event, RegisteredEvent)]
+/// #[event(type = "user.removed")]
+/// struct UserRemoved;
+///
+/// #[derive(Event, RegisteredEvent)]
+/// enum UserEvents {
+///     UserCreated(UserCreated),
+///     UserRemoved(UserRemoved),
+/// }
+/// ```
+#[proc_macro_derive(RegisteredEvent)]
+pub fn derive_registered_event(input: TokenStream) -> TokenStream {
+    expand(input, event::registered_derive)
+}
+
 /// Derives [`cqrs::VersionedEvent`] implementation for structs and enums.
 ///
 /// # Structs

--- a/cqrs-codegen/src/lib.rs
+++ b/cqrs-codegen/src/lib.rs
@@ -69,8 +69,8 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 /// can be either a tuple-variant or a struct-variant).
 ///
 /// Generated implementation of [`cqrs::RegisteredEvent::type_id`] would
-/// match on all variants and return [`core::any::TypeId`] of each variant's
-/// field (__without proxying call to it__, so fields don't have to implement
+/// match on all variants and return [`cqrs::RegisteredEvent::type_id`] of each
+/// variant's field (__with a proxy call__, so fields do have to implement
 /// [`cqrs::RegisteredEvent`] themself).
 ///
 /// # Examples

--- a/cqrs-codegen/tests/registered_event.rs
+++ b/cqrs-codegen/tests/registered_event.rs
@@ -1,0 +1,133 @@
+use std::any::TypeId;
+
+use cqrs::RegisteredEvent as _;
+use cqrs_codegen::{Event, RegisteredEvent};
+
+#[test]
+fn derives_for_struct() {
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event")]
+    struct TestEvent {
+        id: i32,
+        data: String,
+    };
+
+    assert_eq!(TestEvent::default().type_id(), TypeId::of::<TestEvent>());
+}
+
+#[test]
+fn derives_for_generic_struct() {
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.generic")]
+    struct TestEventGeneric<ID, Data>
+        where
+            ID: 'static,
+            Data: 'static,
+    {
+        id: ID,
+        data: Data,
+    };
+
+    type TestEvent = TestEventGeneric<i32, String>;
+
+    assert_eq!(TestEvent::default().type_id(), TypeId::of::<TestEvent>());
+}
+
+#[test]
+fn derives_for_enum() {
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.1")]
+    struct TestEvent1;
+
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.2")]
+    struct TestEvent2;
+
+    #[derive(Event, RegisteredEvent)]
+    enum TestEvent {
+        TestEventTuple(TestEvent1),
+        TestEventStruct { event: TestEvent2 },
+    }
+
+    assert_eq!(
+        TestEvent::TestEventTuple(Default::default()).type_id(),
+        TypeId::of::<TestEvent1>()
+    );
+    assert_eq!(
+        TestEvent::TestEventStruct {
+            event: Default::default()
+        }
+            .type_id(),
+        TypeId::of::<TestEvent2>()
+    );
+}
+
+#[test]
+fn derives_for_generic_enum() {
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.1")]
+    struct TestEvent1;
+
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.2")]
+    struct TestEvent2;
+
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.generic.1")]
+    struct TestEventGeneric1<ID, Data>
+        where
+            ID: 'static,
+            Data: 'static,
+    {
+        id: ID,
+        data: Data,
+    }
+
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.generic.2")]
+    struct TestEventGeneric2<ID, Data>
+        where
+            ID: 'static,
+            Data: 'static,
+    {
+        id: ID,
+        data: Data,
+    }
+
+    #[derive(Event, RegisteredEvent)]
+    enum TestEventGeneric<TE1, TE2, ID, Data>
+        where
+            ID: 'static,
+            Data: 'static,
+    {
+        TestEventTuple(TE1),
+        TestEventStruct { event: TE2 },
+        TestEventTupleGeneric(TestEventGeneric1<ID, Data>),
+        TestEventStructGeneric { event: TestEventGeneric2<ID, Data> },
+    }
+
+    type TestEvent = TestEventGeneric<TestEvent1, TestEvent2, i32, String>;
+
+    assert_eq!(
+        TestEvent::TestEventTuple(Default::default()).type_id(),
+        TypeId::of::<TestEvent1>()
+    );
+    assert_eq!(
+        TestEvent::TestEventStruct {
+            event: Default::default()
+        }
+            .type_id(),
+        TypeId::of::<TestEvent2>()
+    );
+    assert_eq!(
+        TestEvent::TestEventTupleGeneric(Default::default()).type_id(),
+        TypeId::of::<TestEventGeneric1<i32, String>>()
+    );
+    assert_eq!(
+        TestEvent::TestEventStructGeneric {
+            event: Default::default()
+        }
+            .type_id(),
+        TypeId::of::<TestEventGeneric2<i32, String>>()
+    );
+}

--- a/cqrs-codegen/tests/registered_event.rs
+++ b/cqrs-codegen/tests/registered_event.rs
@@ -20,9 +20,9 @@ fn derives_for_generic_struct() {
     #[derive(Default, Event, RegisteredEvent)]
     #[event(type = "test.event.generic")]
     struct TestEventGeneric<ID, Data>
-        where
-            ID: 'static,
-            Data: 'static,
+    where
+        ID: 'static,
+        Data: 'static,
     {
         id: ID,
         data: Data,
@@ -57,7 +57,7 @@ fn derives_for_enum() {
         TestEvent::TestEventStruct {
             event: Default::default()
         }
-            .type_id(),
+        .type_id(),
         TypeId::of::<TestEvent2>()
     );
 }
@@ -75,9 +75,9 @@ fn derives_for_generic_enum() {
     #[derive(Default, Event, RegisteredEvent)]
     #[event(type = "test.event.generic.1")]
     struct TestEventGeneric1<ID, Data>
-        where
-            ID: 'static,
-            Data: 'static,
+    where
+        ID: 'static,
+        Data: 'static,
     {
         id: ID,
         data: Data,
@@ -86,9 +86,9 @@ fn derives_for_generic_enum() {
     #[derive(Default, Event, RegisteredEvent)]
     #[event(type = "test.event.generic.2")]
     struct TestEventGeneric2<ID, Data>
-        where
-            ID: 'static,
-            Data: 'static,
+    where
+        ID: 'static,
+        Data: 'static,
     {
         id: ID,
         data: Data,
@@ -96,9 +96,9 @@ fn derives_for_generic_enum() {
 
     #[derive(Event, RegisteredEvent)]
     enum TestEventGeneric<TE1, TE2, ID, Data>
-        where
-            ID: 'static,
-            Data: 'static,
+    where
+        ID: 'static,
+        Data: 'static,
     {
         TestEventTuple(TE1),
         TestEventStruct { event: TE2 },
@@ -116,7 +116,7 @@ fn derives_for_generic_enum() {
         TestEvent::TestEventStruct {
             event: Default::default()
         }
-            .type_id(),
+        .type_id(),
         TypeId::of::<TestEvent2>()
     );
     assert_eq!(
@@ -127,7 +127,7 @@ fn derives_for_generic_enum() {
         TestEvent::TestEventStructGeneric {
             event: Default::default()
         }
-            .type_id(),
+        .type_id(),
         TypeId::of::<TestEventGeneric2<i32, String>>()
     );
 }

--- a/cqrs-codegen/tests/registered_event.rs
+++ b/cqrs-codegen/tests/registered_event.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::any::TypeId;
 
 use cqrs::RegisteredEvent as _;
@@ -51,14 +53,48 @@ fn derives_for_enum() {
 
     assert_eq!(
         TestEvent::TestEventTuple(Default::default()).type_id(),
-        TypeId::of::<TestEvent1>()
+        TypeId::of::<TestEvent1>(),
     );
     assert_eq!(
         TestEvent::TestEventStruct {
             event: Default::default()
         }
         .type_id(),
-        TypeId::of::<TestEvent2>()
+        TypeId::of::<TestEvent2>(),
+    );
+}
+
+#[test]
+fn derives_for_deeply_nested_enum() {
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.1")]
+    struct TestEvent1;
+
+    #[derive(Default, Event, RegisteredEvent)]
+    #[event(type = "test.event.2")]
+    struct TestEvent2;
+
+    #[derive(Event, RegisteredEvent)]
+    enum TestEvent {
+        TestEventTuple(TestEvent1),
+        TestEventStruct { event: TestEvent2 },
+    }
+
+    #[derive(Event, RegisteredEvent)]
+    enum TestEventNested {
+        TestEvent(TestEvent),
+    }
+
+    assert_eq!(
+        TestEventNested::TestEvent(TestEvent::TestEventTuple(Default::default())).type_id(),
+        TypeId::of::<TestEvent1>(),
+    );
+    assert_eq!(
+        TestEventNested::TestEvent(TestEvent::TestEventStruct {
+            event: Default::default()
+        })
+        .type_id(),
+        TypeId::of::<TestEvent2>(),
     );
 }
 
@@ -110,24 +146,24 @@ fn derives_for_generic_enum() {
 
     assert_eq!(
         TestEvent::TestEventTuple(Default::default()).type_id(),
-        TypeId::of::<TestEvent1>()
+        TypeId::of::<TestEvent1>(),
     );
     assert_eq!(
         TestEvent::TestEventStruct {
             event: Default::default()
         }
         .type_id(),
-        TypeId::of::<TestEvent2>()
+        TypeId::of::<TestEvent2>(),
     );
     assert_eq!(
         TestEvent::TestEventTupleGeneric(Default::default()).type_id(),
-        TypeId::of::<TestEventGeneric1<i32, String>>()
+        TypeId::of::<TestEventGeneric1<i32, String>>(),
     );
     assert_eq!(
         TestEvent::TestEventStructGeneric {
             event: Default::default()
         }
         .type_id(),
-        TypeId::of::<TestEventGeneric2<i32, String>>()
+        TypeId::of::<TestEventGeneric2<i32, String>>(),
     );
 }

--- a/cqrs/src/event_processing.rs
+++ b/cqrs/src/event_processing.rs
@@ -99,9 +99,7 @@ where
 
 pub trait RegisteredEvent: Event + 'static {
     #[inline]
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<Self>()
-    }
+    fn type_id(&self) -> TypeId;
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Also removed 'RegisteredEvent::type_id()' default implementation, as we're generating it with derive macro now.

Example usage:

```rust
#[derive(Event, RegisteredEvent)]
#[event(type = "user.created")]
pub struct UserCreated;

#[derive(Event, RegisteredEvent)]
#[event(type = "user.removed")]
pub struct UserRemoved;

#[derive(Event, RegisteredEvent)]
pub enum UserEvent {
    UserCreated(UserCreated),
    UserRemoved(UserRemoved),
}
```