### PR TITLE
Add 'async_trait bounds to QueryHandler & QueryGateway methods

### DIFF
--- a/cqrs/src/lib.rs
+++ b/cqrs/src/lib.rs
@@ -98,7 +98,9 @@ pub trait QueryGateway<Qr: Query> {
     type Err;
     type Ok;
 
-    async fn query(&self, query: Qr) -> Result<Self::Ok, Self::Err>;
+    async fn query(&self, query: Qr) -> Result<Self::Ok, Self::Err>
+    where
+        Qr: 'async_trait;
 }
 
 #[async_trait(?Send)]
@@ -107,5 +109,7 @@ pub trait QueryHandler<Qr: Query> {
     type Err;
     type Ok;
 
-    async fn handle(&self, query: Qr, ctx: &Self::Context) -> Result<Self::Ok, Self::Err>;
+    async fn handle(&self, query: Qr, ctx: &Self::Context) -> Result<Self::Ok, Self::Err>
+    where
+        Qr: 'async_trait;
 }


### PR DESCRIPTION
Add `'async_trait` lifetime bounds to `QueryGateway::query` & `QueryHandler::handle` to be able to use `non-'static` type parameters in generic queries.