### PR TITLE
Relax CommandHandler associated types' trait bounds

### DIFF
--- a/cqrs-core/src/command.rs
+++ b/cqrs-core/src/command.rs
@@ -51,17 +51,16 @@ pub trait CommandHandler<Cmd: Command> {
     /// This should be used to provide any additional services/resources
     /// required to handle the [`Command`].
     type Context: ?Sized;
-    /// Type of [`Event`] produced as a result of the [`Command`] handling.
-    type Event: Event;
+    /// Type of event produced as a result of the [`Command`] handling.
+    /// If it doesn't produce any events, consider to specify `()`.
+    type Event;
     /// Type of the error if [`Command`] handling fails. If it never fails,
     /// consider to specify [`Infallible`].
     ///
     /// [`Infallible`]: std::convert::Infallible.
     type Err;
-    /// Type of the result of successful [`Command`] handling. It should be
-    /// convertible into [`Event`]s collection (see [`IntoEvents`] trait for
-    /// details).
-    type Ok: IntoEvents<Self::Event>;
+    /// Type of the result of successful [`Command`] handling.
+    type Ok;
 
     /// Handles and processes given [`Command`] for its [`Aggregate`].
     async fn handle(&self, cmd: Cmd, ctx: &Self::Context) -> Result<Self::Ok, Self::Err>;

--- a/cqrs/src/lifecycle/basic.rs
+++ b/cqrs/src/lifecycle/basic.rs
@@ -3,13 +3,13 @@ use std::{convert, fmt};
 use cqrs_core::{
     Aggregate, Command, CommandHandler, Event, EventNumber, EventSink, EventSource, EventSourced,
     HydratedAggregate, IntoEvents as _, NumberedEvent, SnapshotRecommendation, SnapshotSink,
-    SnapshotSource, SnapshotStrategy,
+    SnapshotSource, SnapshotStrategy, IntoEvents,
 };
 use derive_more::{Display, Error, From};
 use futures::{future, TryStreamExt as _};
 use smallvec::SmallVec;
 
-use super::{BufferedContext, CommandHandlerContext, CommandHandlerErr, CommandHandlerEvent};
+use super::{BufferedContext, CommandHandlerContext,  CommandHandlerOk,CommandHandlerErr, CommandHandlerEvent};
 
 #[derive(Debug)]
 pub struct Basic<Snp> {
@@ -329,7 +329,8 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: 'static,
+        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
         Mt: ?Sized,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
         SsSnk: SnapshotSink<Cmd::Aggregate> + ?Sized,
@@ -396,7 +397,8 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: 'static,
+        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
         Mt: ?Sized,
         SsSrc: SnapshotSource<Cmd::Aggregate> + ?Sized,
         EvSrc: EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>> + ?Sized,

--- a/cqrs/src/lifecycle/mod.rs
+++ b/cqrs/src/lifecycle/mod.rs
@@ -14,6 +14,7 @@ pub use self::{
     r#static::Static,
 };
 
+type CommandHandlerOk<Cmd> = <<Cmd as Command>::Aggregate as CommandHandler<Cmd>>::Ok;
 type CommandHandlerErr<Cmd> = <<Cmd as Command>::Aggregate as CommandHandler<Cmd>>::Err;
 type CommandHandlerEvent<Cmd> = <<Cmd as Command>::Aggregate as CommandHandler<Cmd>>::Event;
 type CommandHandlerContext<Cmd> = <<Cmd as Command>::Aggregate as CommandHandler<Cmd>>::Context;

--- a/cqrs/src/lifecycle/static.rs
+++ b/cqrs/src/lifecycle/static.rs
@@ -3,7 +3,7 @@ use std::borrow::Borrow;
 use async_trait::async_trait;
 use cqrs_core::{
     Aggregate, Command, CommandHandler, Event, EventSink, EventSource, EventSourced,
-    HydratedAggregate, SnapshotSink, SnapshotSource, SnapshotStrategy,
+    HydratedAggregate, SnapshotSink, SnapshotSource, SnapshotStrategy, IntoEvents,
 };
 
 use crate::{CommandBus, EventHandler, EventProcessingConfiguration, RegisteredEvent};
@@ -12,7 +12,7 @@ use super::{
     Basic, BorrowableAsContext, BufferedContext, CommandHandlerContext, CommandHandlerErr,
     CommandHandlerEvent, Context, ContextWithMeta, EventSinkErr, EventSourceErr,
     ExecAndPersistError, LoadError, LoadExecAndPersistError, LoadRehydrateAndPersistError,
-    PersistError, SnapshotSinkErr, SnapshotSourceErr,
+    PersistError, SnapshotSinkErr, SnapshotSourceErr, CommandHandlerOk,
 };
 
 #[derive(Debug)]
@@ -246,7 +246,8 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: 'static,
+        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
         Mt: ?Sized,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
         SsSnk: SnapshotSink<Cmd::Aggregate> + ?Sized,
@@ -284,7 +285,8 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: 'static,
+        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
         Mt: ?Sized,
         SsSrc: SnapshotSource<Cmd::Aggregate> + ?Sized,
         EvSrc: EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>> + ?Sized,
@@ -346,7 +348,8 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: 'static,
+        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
         SsSnk: SnapshotSink<Cmd::Aggregate> + ?Sized,
         Impl: Borrow<EvSnk> + Borrow<SsSnk>,
@@ -382,7 +385,8 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: 'static,
+        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
         SsSrc: SnapshotSource<Cmd::Aggregate> + ?Sized,
         EvSrc: EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>> + ?Sized,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
@@ -428,7 +432,8 @@ where
     Snp: SnapshotStrategy,
     Cmd: Command,
     Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-    CommandHandlerEvent<Cmd>: 'static,
+    CommandHandlerEvent<Cmd>: Event + 'static,
+    CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
     Impl: SnapshotSource<Cmd::Aggregate>
         + EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>>
         + EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt>
@@ -475,7 +480,8 @@ where
     Mt: 'a,
     Cmd: Command,
     Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-    CommandHandlerEvent<Cmd>: 'static,
+    CommandHandlerEvent<Cmd>: Event + 'static,
+    CommandHandlerOk<Cmd>: IntoEvents<CommandHandlerEvent<Cmd>> + 'static,
     Impl: SnapshotSource<Cmd::Aggregate>
         + EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>>
         + EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt>


### PR DESCRIPTION
Move `type Event: Event` and `type Ok: IntoEvents` trait bounds out of `CommandHandler` trait in order to be able to implement commands with custom return types.