### PR TITLE
Remove cqrs::CommandGateway trait bounds

### DIFF
--- a/cqrs/src/lib.rs
+++ b/cqrs/src/lib.rs
@@ -66,7 +66,7 @@ pub use self::{
 };
 
 #[async_trait(?Send)]
-pub trait CommandGateway<Cmd: Command, Mt> {
+pub trait CommandGateway<Cmd, Mt> {
     type Err;
     type Ok;
 


### PR DESCRIPTION
Remove unnecessary trait bounds from cars::CommandGateway.