### PR TITLE
Relax EventHandler trait `Ev: cqrs::Event` bound

### DIFF
--- a/cqrs/src/event_processing.rs
+++ b/cqrs/src/event_processing.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use cqrs_core::Event;
 
 #[async_trait(?Send)]
-pub trait EventHandler<Ev: Event + ?Sized> {
+pub trait EventHandler<Ev: ?Sized> {
     type Context: ?Sized;
     type Err;
 


### PR DESCRIPTION
The bound isn't actually required, and it limits some edge case implementations where `Ev: !cqrs::Event`.