### PR TITLE
Relax `EventSink` bounds

### DIFF
--- a/cqrs-core/src/event.rs
+++ b/cqrs-core/src/event.rs
@@ -135,8 +135,7 @@ where
 #[async_trait(?Send)]
 pub trait EventSink<Agg, Ev, Mt>
 where
-    Agg: Aggregate + EventSourced<Ev>,
-    Ev: Event,
+    Agg: Aggregate,
     Mt: ?Sized,
 {
     /// Type of the error if persisting [`Event`]s fails.


### PR DESCRIPTION
`EventSink` has redundant `EventSourced` and `Event` bounds that are not related to events persisting process.