### PR TITLE
Relax `Event` trait bounds

### DIFF
--- a/cqrs-core/src/_aggregate.rs
+++ b/cqrs-core/src/_aggregate.rs
@@ -7,21 +7,17 @@ use crate::{
 };
 
 /// An iterable and sliceable list of events.
-pub trait Events<E>: IntoIterator<Item = E> + AsRef<[E]>
-where
-    E: Event,
-{
+pub trait Events<E>: IntoIterator<Item = E> + AsRef<[E]> {
 }
 
 impl<T, E> Events<E> for T
 where
     T: IntoIterator<Item = E> + AsRef<[E]>,
-    E: Event,
 {
 }
 
 /// An event that can be serialized to a buffer.
-pub trait SerializableEvent: Event {
+pub trait SerializableEvent {
     /// The error type.
     type Error: CqrsError;
 
@@ -30,7 +26,7 @@ pub trait SerializableEvent: Event {
 }
 
 /// An event that can be deserialized from a buffer.
-pub trait DeserializableEvent: Event + Sized {
+pub trait DeserializableEvent: Sized {
     /// The error type.
     type Error: CqrsError;
 

--- a/cqrs-core/src/aggregate.rs
+++ b/cqrs-core/src/aggregate.rs
@@ -175,7 +175,7 @@ impl<Agg> HydratedAggregate<Agg> {
     pub fn apply<'a, Ev, IntoEv>(&mut self, event: IntoEv)
     where
         IntoEv: Into<NumberedEvent<&'a Ev>>,
-        Ev: Event + 'a,
+        Ev: 'a,
         Agg: EventSourced<Ev>,
     {
         let e = event.into();
@@ -190,7 +190,7 @@ impl<Agg> HydratedAggregate<Agg> {
     where
         Iter: IntoIterator<Item = IntoEv>,
         IntoEv: Into<NumberedEvent<&'a Ev>>,
-        Ev: Event + 'a,
+        Ev: 'a,
         Agg: EventSourced<Ev>,
     {
         for event in events {

--- a/cqrs-core/src/event.rs
+++ b/cqrs-core/src/event.rs
@@ -31,13 +31,13 @@ pub trait Event {
 /// State that can be calculated by applying specified [`Event`].
 ///
 /// Usually, implemented by an [`Aggregate`].
-pub trait EventSourced<Ev: Event + ?Sized> {
+pub trait EventSourced<Ev: ?Sized> {
     /// Applies given [`Event`] to the current state.
     fn apply(&mut self, event: &Ev);
 }
 
 /// [`Event`] (or a set of them) providing its [`EventType`].
-pub trait TypedEvent: Event {
+pub trait TypedEvent {
     /// All available types of this [`Event`].
     const EVENT_TYPES: &'static [EventType];
 }
@@ -50,7 +50,7 @@ pub trait TypedEvent: Event {
 /// version of [`Event`] to implement trait [`From`] its previous versions, so
 /// they can be automatically transformed into the latest actual version of
 /// [`Event`].
-pub trait VersionedEvent: Event {
+pub trait VersionedEvent {
     /// Returns [`Event`]'s version.
     ///
     /// _Note:_ This should effectively be a constant value, and should never
@@ -106,7 +106,6 @@ impl<'a, Ev, Mt> From<&'a NumberedEventWithMeta<Ev, Mt>> for NumberedEvent<&'a E
 pub trait EventSource<Agg, Ev>
 where
     Agg: Aggregate + EventSourced<Ev>,
-    Ev: Event,
 {
     /// Type of the error if reading [`NumberedEvent`]s fails.
     /// If it never fails, consider to specify [`Infallible`].

--- a/cqrs-proptest/src/lib.rs
+++ b/cqrs-proptest/src/lib.rs
@@ -171,7 +171,7 @@ use std::{fmt, marker::PhantomData};
 ///     .unwrap()
 ///     .current();
 /// ```
-pub fn arb_events<E: Event + fmt::Debug>(
+pub fn arb_events<E: fmt::Debug>(
     event_strategy: impl Strategy<Value = E>,
     size: impl Into<prop::collection::SizeRange>,
 ) -> impl Strategy<Value = Vec<E>> {

--- a/cqrs/src/event_processing.rs
+++ b/cqrs/src/event_processing.rs
@@ -62,7 +62,7 @@ impl<'a, 'b, F, Fut, Ev, Ctx, Err> EventHandler<Ev> for EventHandlerTryFn<'a, 'b
 where
     F: Fn(&'a Ev, &'b Ctx) -> Fut,
     Fut: Future<Output = Result<(), Err>>,
-    Ev: Event + ?Sized + 'a,
+    Ev: ?Sized + 'a,
     Ctx: ?Sized + 'b,
     Err: 'static,
 {
@@ -75,7 +75,7 @@ where
     }
 }
 
-async fn some<Ev: Event + ?Sized>(ev: &Ev, ctx: &()) -> Result<(), std::convert::Infallible> {
+async fn some<Ev: ?Sized>(ev: &Ev, ctx: &()) -> Result<(), std::convert::Infallible> {
     Ok(())
 }
 
@@ -92,12 +92,12 @@ fn test_some() {
 fn assert_is_event_handler<T, Ev>(_: T)
 where
     T: EventHandler<Ev>,
-    Ev: Event + ?Sized,
+    Ev: ?Sized,
 {
 }
 */
 
-pub trait RegisteredEvent: Event + 'static {
+pub trait RegisteredEvent: 'static {
     #[inline]
     fn type_id(&self) -> TypeId;
 }
@@ -147,9 +147,9 @@ impl EventProcessingConfigurationBuilder {
     #[inline]
     pub fn register_event_handler<Ev, AsEv, Ctx, Err, H>(&mut self, handler: H)
     where
-        Ev: Event + ?Sized + 'static,
+        Ev: ?Sized + 'static,
         for<'e> &'e Ev: TryFrom<&'e AsEv>,
-        AsEv: Event + ?Sized + 'static,
+        AsEv: ?Sized + 'static,
         Ctx: AsRef<H::Context> + ?Sized + 'static,
         Err: From<H::Err> + 'static,
         H: EventHandler<Ev> + Send + Sync + 'static,
@@ -168,9 +168,9 @@ sa::assert_impl_all!(EventHandlersRegistry: Send, Sync);
 impl EventHandlersRegistry {
     fn register<Ev, AsEv, Ctx, Err, H>(&mut self, handler: H)
     where
-        Ev: Event + ?Sized + 'static,
+        Ev: ?Sized + 'static,
         for<'e> &'e Ev: TryFrom<&'e AsEv>,
-        AsEv: Event + ?Sized + 'static,
+        AsEv: ?Sized + 'static,
         Ctx: AsRef<H::Context> + ?Sized + 'static,
         Err: From<H::Err> + 'static,
         H: EventHandler<Ev> + Send + Sync + 'static,
@@ -239,7 +239,7 @@ sa::assert_impl_all!(DynEventHandler<u8, std::env::Args, std::env::Args>: Send, 
 #[async_trait(?Send)]
 impl<Ev, Ctx, Err> EventHandler<Ev> for DynEventHandler<Ev, Ctx, Err>
 where
-    Ev: Event + ?Sized,
+    Ev: ?Sized,
     Ctx: ?Sized,
 {
     type Context = Ctx;
@@ -269,9 +269,9 @@ sa::assert_impl_all!(
 #[async_trait(?Send)]
 impl<AsEv, H, Ev, Ctx, Err> EventHandler<AsEv> for RawEventHandler<H, Ev, Ctx, Err>
 where
-    AsEv: Event + ?Sized,
+    AsEv: ?Sized,
     H: EventHandler<Ev>,
-    Ev: Event + ?Sized,
+    Ev: ?Sized,
     for<'e> &'e Ev: TryFrom<&'e AsEv>,
     Ctx: AsRef<H::Context> + ?Sized,
     Err: From<H::Err>,
@@ -297,9 +297,9 @@ where
 
 pub trait EventHandlersRegistrar<Ev, AsEv, Ctx, Err>
 where
-    Ev: Event + ?Sized + 'static,
+    Ev: ?Sized + 'static,
     for<'e> &'e Ev: TryFrom<&'e AsEv>,
-    AsEv: Event + ?Sized + 'static,
+    AsEv: ?Sized + 'static,
     Ctx: ?Sized + 'static,
     Err: 'static,
 {

--- a/cqrs/src/lib.rs
+++ b/cqrs/src/lib.rs
@@ -83,9 +83,9 @@ pub trait CommandBus<Cmd: Command> {
         Cmd: 'async_trait;
 }
 
-pub trait DomainEvent: Event {}
+pub trait DomainEvent {}
 
-pub trait AggregateEvent: TypedEvent {
+pub trait AggregateEvent {
     type Aggregate: Aggregate;
 }
 

--- a/cqrs/src/lifecycle/basic.rs
+++ b/cqrs/src/lifecycle/basic.rs
@@ -74,7 +74,6 @@ impl<Snp> Basic<Snp> {
     ) -> Result<(), EvSrc::Err>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
     {
         event_source
@@ -90,7 +89,6 @@ impl<Snp> Basic<Snp> {
     ) -> Result<Option<HydratedAggregate<Agg>>, LoadError<SsSrc::Err, EvSrc::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         Repo: AsRef<SsSrc> + AsRef<EvSrc> + ?Sized,
@@ -117,7 +115,6 @@ impl<Snp> Basic<Snp> {
     ) -> Result<Vec<HydratedAggregate<Agg>>, LoadError<SsSrc::Err, EvSrc::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         Repo: AsRef<SsSrc> + AsRef<EvSrc> + ?Sized,
@@ -233,7 +230,6 @@ where
     ) -> Result<(), LoadRehydrateAndPersistError<SsSrc::Err, EvSrc::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         SsSnk: SnapshotSink<Agg> + ?Sized,
@@ -260,7 +256,6 @@ where
     ) -> Result<(), LoadRehydrateAndPersistError<SsSrc::Err, EvSrc::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         SsSnk: SnapshotSink<Agg> + ?Sized,
@@ -289,7 +284,7 @@ where
     ) -> Result<(), PersistError<EvSnk::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event + 'static,
+        Ev: 'static,
         Evs: AsRef<[NumberedEvent<Ev>]>,
         Mt: ?Sized,
         EvSnk: EventSink<Agg, Ev, Mt> + ?Sized,
@@ -330,7 +325,7 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerEvent<Cmd>: 'static,
         CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
         Mt: ?Sized,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
@@ -394,7 +389,7 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerEvent<Cmd>: 'static,
         CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
         Mt: ?Sized,
         SsSrc: SnapshotSource<Cmd::Aggregate> + ?Sized,

--- a/cqrs/src/lifecycle/static.rs
+++ b/cqrs/src/lifecycle/static.rs
@@ -87,7 +87,6 @@ impl<Snp, Ctx> Static<Snp, Ctx> {
     ) -> Result<(), EvSrc::Err>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         Ctx: AsRef<EvSrc>,
     {
@@ -103,7 +102,6 @@ impl<Snp, Ctx> Static<Snp, Ctx> {
     ) -> Result<Option<HydratedAggregate<Agg>>, LoadError<SsSrc::Err, EvSrc::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         Ctx: AsRef<SsSrc> + AsRef<EvSrc>,
@@ -120,7 +118,6 @@ impl<Snp, Ctx> Static<Snp, Ctx> {
     ) -> Result<Vec<HydratedAggregate<Agg>>, LoadError<SsSrc::Err, EvSrc::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         Ctx: AsRef<SsSrc> + AsRef<EvSrc>,
@@ -172,7 +169,6 @@ where
     ) -> Result<(), LoadRehydrateAndPersistError<SsSrc::Err, EvSrc::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         SsSnk: SnapshotSink<Agg> + ?Sized,
@@ -190,7 +186,6 @@ where
     ) -> Result<(), LoadRehydrateAndPersistError<SsSrc::Err, EvSrc::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event,
         SsSrc: SnapshotSource<Agg> + ?Sized,
         EvSrc: EventSource<Agg, Ev> + ?Sized,
         SsSnk: SnapshotSink<Agg> + ?Sized,
@@ -215,7 +210,7 @@ where
     ) -> Result<(), PersistError<EvSnk::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event + 'static,
+        Ev: 'static,
         Evs: AsRef<[NumberedEvent<Ev>]>,
         Mt: ?Sized,
         EvSnk: EventSink<Agg, Ev, Mt> + ?Sized,
@@ -246,7 +241,7 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerEvent<Cmd>: 'static,
         CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
         Mt: ?Sized,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
@@ -285,7 +280,7 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerEvent<Cmd>: 'static,
         CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
         Mt: ?Sized,
         SsSrc: SnapshotSource<Cmd::Aggregate> + ?Sized,
@@ -319,7 +314,7 @@ where
     ) -> Result<(), PersistError<EvSnk::Err, SsSnk::Err>>
     where
         Agg: Aggregate + EventSourced<Ev>,
-        Ev: Event + 'static,
+        Ev: 'static,
         Evs: AsRef<[NumberedEvent<Ev>]>,
         EvSnk: EventSink<Agg, Ev, Mt> + ?Sized,
         SsSnk: SnapshotSink<Agg> + ?Sized,
@@ -348,7 +343,7 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerEvent<Cmd>: 'static,
         CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
         EvSnk: EventSink<Cmd::Aggregate, CommandHandlerEvent<Cmd>, Mt> + ?Sized,
         SsSnk: SnapshotSink<Cmd::Aggregate> + ?Sized,
@@ -385,7 +380,7 @@ where
     where
         Cmd: Command,
         Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-        CommandHandlerEvent<Cmd>: Event + 'static,
+        CommandHandlerEvent<Cmd>: 'static,
         CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
         SsSrc: SnapshotSource<Cmd::Aggregate> + ?Sized,
         EvSrc: EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>> + ?Sized,
@@ -432,7 +427,7 @@ where
     Snp: SnapshotStrategy,
     Cmd: Command,
     Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-    CommandHandlerEvent<Cmd>: Event + 'static,
+    CommandHandlerEvent<Cmd>: 'static,
     CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
     Impl: SnapshotSource<Cmd::Aggregate>
         + EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>>
@@ -480,7 +475,7 @@ where
     Mt: 'a,
     Cmd: Command,
     Cmd::Aggregate: CommandHandler<Cmd> + EventSourced<CommandHandlerEvent<Cmd>>,
-    CommandHandlerEvent<Cmd>: Event + 'static,
+    CommandHandlerEvent<Cmd>: 'static,
     CommandHandlerOk<Cmd>: AsRef<[NumberedEvent<CommandHandlerEvent<Cmd>>]> + 'static,
     Impl: SnapshotSource<Cmd::Aggregate>
         + EventSource<Cmd::Aggregate, CommandHandlerEvent<Cmd>>


### PR DESCRIPTION
Relax `Event` bounds to allow combining `cqrs::*Event` traits generic implementations:

```rust
#[detive(cqrs::RegisteredEvent)] // do not require `cqrs::Event`.
struct MyGenericEvent<T> {
  my_type: T,
}

type MyConcreteEvent = MyGenericEvent<MyType>;

impl cqrs::Event for MyConcreteEvent { .. }
impl cqrs::VersionedEvent for MyConcreteEvent { .. }
```