### PR TITLE
Refactor `const_concat_slices!` to support generic parameters

### DIFF
--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -82,7 +82,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
         {
             fn event_type(&self) -> ::cqrs::EventType {
                 match *self {
-                    #( Self::#variant(ref ev) => ev.event_type(), )*
+                    #( #variant, )*
                 }
             }
         }

--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -77,6 +77,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
     let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics ::cqrs::Event for #type_name #ty_generics
         #where_clause
         {

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -109,12 +109,16 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
         #[automatically_derived]
         impl#impl_generics ::cqrs::TypedEvent for #type_name#ty_generics #where_clause {
             #[doc = #const_doc]
-            const EVENT_TYPES: &'static [::cqrs::EventType] = {
+            const EVENT_TYPES: &'static [::cqrs::EventType] =
                 ::cqrs::private::slice_arr(
                     &const {
                         const __LEN: usize = 128;
                         if #len > __LEN {
-                            panic!("`cqrs::TypedEvent::EVENT_TYPES` limit reached");
+                            panic!(
+                                "`cqrs::TypedEvent::EVENT_TYPES` limit reached: \
+                                 {} > {__LEN}",
+                                #len,
+                            );
                         }
 
                         let mut out = [""; __LEN];
@@ -132,8 +136,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
                         out
                     },
                     #len,
-                )
-            };
+                );
         }
     })
 }

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -112,7 +112,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
             const EVENT_TYPES: &'static [::cqrs::EventType] = {
                 ::cqrs::private::slice_arr(
                     &const {
-                        const __LEN: usize = 64;
+                        const __LEN: usize = 128;
                         if #len > __LEN {
                             panic!("`cqrs::TypedEvent::EVENT_TYPES` limit reached");
                         }

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -118,7 +118,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
                         }
 
                         let mut out = [""; __LEN];
-                        let len = 0;
+                        let mut len = 0;
 
                         #({
                             let mut i = 0;

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -114,11 +114,8 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
                     &const {
                         const __LEN: usize = 128;
                         if #len > __LEN {
-                            panic!(
-                                "`cqrs::TypedEvent::EVENT_TYPES` limit reached: \
-                                 {} > {__LEN}",
-                                #len,
-                            );
+                            panic!("`cqrs::TypedEvent::EVENT_TYPES` limit \
+                                    reached: 128");
                         }
 
                         let mut out = [""; __LEN];

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -106,7 +106,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
         impl#impl_generics ::cqrs::TypedEvent for #type_name#ty_generics #where_clause {
             #[doc = #const_doc]
             const EVENT_TYPES: &'static [::cqrs::EventType] = {
-                ::cqrs::const_concat_slices!(::cqrs::EventType, #( #subtypes ),*)
+                ::cqrs::const_concat_slices!(#( #subtypes ),*)
             };
         }
     })

--- a/cqrs-codegen/impl/src/util.rs
+++ b/cqrs-codegen/impl/src/util.rs
@@ -232,7 +232,8 @@ fn find_nested_meta_impl(
             ));
         }
 
-        let parsed = meta.parse_args_with(Meta::parse_terminated)
+        let parsed = meta
+            .parse_args_with(Meta::parse_terminated)
             .map_err(|e| syn::Error::new(Span::call_site(), format!("wut: {e}")))?;
         nested_meta.replace((attr.span(), parsed));
     }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($ty:ty, $a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 255;
+                const __LEN: usize = 32;
                 let mut out = [""; __LEN];
                 let mut i = 0;
                 while i < $a.len() {

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 255;
+                const __LEN: usize = 512;
                 if $a.len() + $b.len() > __LEN {
                     compile_error!("concatenated slices exceed maximum length");
                 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,9 +46,9 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 4080;
+                const __LEN: usize = 255;
                 if $a.len() + $b.len() > __LEN {
-                    compile_error!("concatenated slices exceed maximum length");
+                    panic!("concatenated slices exceed maximum length");
                 }
 
                 let mut out = [""; __LEN];

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,12 @@ pub mod private {
         arr: &'static [&'static str; N],
         at: usize,
     ) -> &'static [&'static str] {
+        if at > N {
+            panic!("index out of bounds: {at} > {N}");
+        }
         #[allow(unsafe_code, reason = "macro internals")]
-        unsafe { std::slice::from_raw_parts(arr.as_ptr(), at) }
+        unsafe {
+            std::slice::from_raw_parts(arr.as_ptr(), at)
+        }
     }
 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 32;
+                const __LEN: usize = 255;
                 if $a.len() + $b.len() > __LEN {
                     compile_error!("concatenated slices exceed maximum length");
                 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 512;
+                const __LEN: usize = 4080;
                 if $a.len() + $b.len() > __LEN {
                     compile_error!("concatenated slices exceed maximum length");
                 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -39,42 +39,6 @@ pub use self::{aggregate::*, command::*, event::*};
 /// Helper alias for pin-boxed `?Send` [`Stream`] which yields [`Result`]s.
 pub type LocalBoxTryStream<'a, I, E> = Pin<Box<dyn Stream<Item = Result<I, E>> + 'a>>;
 
-/// Concatenates slices at compile time.
-#[macro_export]
-macro_rules! const_concat_slices {
-    ($a:expr) => {$a};
-    ($a:expr, $b:expr $(,)*) => {
-        $crate::private::slice_arr(
-            &const {
-                const __LEN: usize = 255;
-                if $a.len() + $b.len() > __LEN {
-                    panic!("concatenated slices exceed maximum length");
-                }
-
-                let mut out = [""; __LEN];
-                let mut i = 0;
-                while i < $a.len() {
-                    out[i] = $a[i];
-                    i += 1;
-                }
-                i = 0;
-                while i < $b.len() {
-                    out[i + $a.len()] = $b[i];
-                    i += 1;
-                }
-                out
-            },
-            $a.len() + $b.len(),
-        )
-    };
-    ($a:expr, $b:expr, $($c:expr),+ $(,)*) => {
-        $crate::const_concat_slices!(
-            $a,
-            $crate::const_concat_slices!($b, $($c),+)
-        )
-    };
-}
-
 #[doc(hidden)]
 pub mod private {
     /// Slices an array of strings at compile time.


### PR DESCRIPTION
`Event` macro can't handle generic parameters even after: #21, #28

The actual problem is that we can't evaluate `__LEN` in `const_concat_slices!` due to compiler limitations.

Solution is to allocate `[""; 255]` (255 is just a constant length we don't need to evaluate)  array and slice it to actual length.