### PR TITLE
Add `StaticTypedEvent`

### DIFF
--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -82,7 +82,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
         {
             fn event_type(&self) -> ::cqrs::EventType {
                 match *self {
-                    #( Self::#variant(ref ev) => ev.event_type(), )*
+                    #( #variant, )*
                 }
             }
         }

--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -2,7 +2,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_quote, spanned::Spanned as _, Error, Result};
+use syn::{parse_quote, Result};
 use synstructure::Structure;
 
 use crate::{event::typed_event, util};
@@ -14,7 +14,6 @@ const TRAIT_NAME: &str = "Event";
 pub fn derive(input: syn::DeriveInput) -> Result<TokenStream> {
     let mut s = util::derive(input.clone(), TRAIT_NAME, derive_struct, derive_enum)?;
     s.extend(typed_event::derive(input)?);
-    panic!("{}", s);
     Ok(s)
 }
 
@@ -85,8 +84,8 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
     let variant = data.variants.iter().map(|v| {
         let ident = &v.ident;
         let field = &v.fields.iter().next().expect("already checked");
-        if field.ident.is_some() {
-            quote! { Self::#ident { #field: ref ev } => ev.event_type() }
+        if let Some(field_ident) = &field.ident {
+            quote! { Self::#ident { #field_ident: ref ev } => ev.event_type() }
         } else {
             quote! { Self::#ident(ref ev) => ev.event_type() }
         }

--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -2,7 +2,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_quote, spanned::Spanned as _, Error, Result};
+use syn::{parse_quote, Result};
 use synstructure::Structure;
 
 use crate::{event::typed_event, util};
@@ -14,6 +14,7 @@ const TRAIT_NAME: &str = "Event";
 pub fn derive(input: syn::DeriveInput) -> Result<TokenStream> {
     let mut s = util::derive(input.clone(), TRAIT_NAME, derive_struct, derive_enum)?;
     s.extend(typed_event::derive(input)?);
+    panic!("{}", s);
     Ok(s)
 }
 
@@ -22,20 +23,37 @@ fn derive_struct(input: syn::DeriveInput) -> Result<TokenStream> {
     let meta = util::get_nested_meta(&input.attrs, super::ATTR_NAME)?;
 
     let const_val = parse_event_type_from_nested_meta(&meta)?;
-    let const_doc = format!("Type name of [`{}`] event", input.ident);
-    let additional = quote! {
-        #[doc = #const_doc]
-        pub const EVENT_TYPE: ::cqrs::EventType = #const_val;
-    };
+    let const_doc = format!("Type name of [`{}`] event.", input.ident);
 
-    let body = quote! {
-        #[inline(always)]
-        fn event_type(&self) -> ::cqrs::EventType {
-            Self::EVENT_TYPE
+    let type_name = &input.ident;
+    let (impl_gens, ty_gens, type_where_clause) = input.generics.split_for_impl();
+
+    let mut event_where_clause = type_where_clause
+        .cloned()
+        .unwrap_or_else(|| parse_quote!(where));
+    event_where_clause
+        .predicates
+        .push(parse_quote!(Self: ::cqrs::StaticTypedEvent));
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl#impl_gens ::cqrs::StaticTypedEvent for #type_name#ty_gens
+        #type_where_clause
+        {
+            #[doc = #const_doc]
+            const EVENT_TYPE: ::cqrs::EventType = #const_val;
         }
-    };
 
-    util::render_struct(&input, quote!(::cqrs::Event), body, Some(additional))
+        #[automatically_derived]
+        impl#impl_gens ::cqrs::Event for #type_name#ty_gens
+        #event_where_clause
+        {
+            #[inline(always)]
+            fn event_type(&self) -> ::cqrs::EventType {
+                <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
+            }
+        }
+    })
 }
 
 /// Implements [`crate::event_derive`] macro expansion for enums
@@ -115,21 +133,28 @@ mod spec {
 
         let output = quote! {
             #[automatically_derived]
-            impl Event {
-                #[doc = "Type name of [`Event`] event"]
-                pub const EVENT_TYPE: ::cqrs::EventType = "event";
+            impl ::cqrs::StaticTypedEvent for Event {
+                #[doc = "Type name of [`Event`] event."]
+                const EVENT_TYPE: ::cqrs::EventType = "event";
             }
-
             #[automatically_derived]
-            impl ::cqrs::Event for Event {
+            impl ::cqrs::Event for Event
+            where
+                Self: ::cqrs::StaticTypedEvent
+            {
                 #[inline(always)]
                 fn event_type(&self) -> ::cqrs::EventType {
-                    Self::EVENT_TYPE
+                    <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
                 }
             }
             #[automatically_derived]
-            impl ::cqrs::TypedEvent for Event {
-                const EVENT_TYPES: &'static [::cqrs::EventType] = &[Self::EVENT_TYPE];
+            impl ::cqrs::TypedEvent for Event
+            where
+                Self: ::cqrs::StaticTypedEvent
+            {
+                const EVENT_TYPES: &'static [::cqrs::EventType] = &[
+                    <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
+                ];
             }
         };
 
@@ -150,7 +175,11 @@ mod spec {
         let output = quote! {
             const _: () = {
                 #[automatically_derived]
-                impl ::cqrs::Event for Event {
+                impl ::cqrs::Event for Event
+                where
+                    Event1: ::cqrs::Event,
+                    Event2: ::cqrs::Event
+                {
                     fn event_type(&self) -> ::cqrs::EventType {
                         match *self {
                             Event::Event1(ref ev,) => {{ ev.event_type() }}
@@ -166,10 +195,39 @@ mod spec {
             {
                 #[doc = "Type names of [`Event`] events."]
                 const EVENT_TYPES: &'static [::cqrs::EventType] = {
-                    ::cqrs::const_concat_slices!(
-                        ::cqrs::EventType,
-                        <Event1 as ::cqrs::TypedEvent>::EVENT_TYPES,
-                        <Event2 as ::cqrs::TypedEvent>::EVENT_TYPES
+                    ::cqrs::private::slice_arr(
+                        &const {
+                            const __LEN: usize = 128;
+                            if 0
+                                + <Event1 as ::cqrs::TypedEvent>::EVENT_TYPES
+                                     .len()
+                                + <Event2 as ::cqrs::TypedEvent>::EVENT_TYPES
+                                     .len()
+                                > __LEN {
+                                panic!("`cqrs::TypedEvent::EVENT_TYPES` limit reached");
+                            }
+
+                            let mut out = [""; __LEN];
+                            let mut len = 0;
+
+                            let mut i = 0;
+                            while i < <Event1 as ::cqrs::TypedEvent>::EVENT_TYPES.len() {
+                                out[len] = <Event1 as ::cqrs::TypedEvent>::EVENT_TYPES[i];
+                                i += 1;
+                                len += 1;
+                            }
+
+                            let mut i = 0;
+                            while i < <Event2 as ::cqrs::TypedEvent>::EVENT_TYPES.len() {
+                                out[len] = <Event2 as ::cqrs::TypedEvent>::EVENT_TYPES[i];
+                                i += 1;
+                                len += 1;
+                            }
+
+                            out
+                        },
+                        0 + <Event1 as ::cqrs::TypedEvent>::EVENT_TYPES.len()
+                          + <Event2 as ::cqrs::TypedEvent>::EVENT_TYPES.len(),
                     )
                 };
             }

--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -77,6 +77,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
     let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics ::cqrs::Event for #type_name #ty_generics
         #where_clause
         {

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -112,7 +112,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
             const EVENT_TYPES: &'static [::cqrs::EventType] = {
                 ::cqrs::private::slice_arr(
                     &const {
-                        const __LEN: usize = 64;
+                        const __LEN: usize = 128;
                         if #len > __LEN {
                             panic!("`cqrs::TypedEvent::EVENT_TYPES` limit reached");
                         }

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -118,7 +118,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
                         }
 
                         let mut out = [""; __LEN];
-                        let len = 0;
+                        let mut len = 0;
 
                         #({
                             let mut i = 0;

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -106,7 +106,7 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
         impl#impl_generics ::cqrs::TypedEvent for #type_name#ty_generics #where_clause {
             #[doc = #const_doc]
             const EVENT_TYPES: &'static [::cqrs::EventType] = {
-                ::cqrs::const_concat_slices!(::cqrs::EventType, #( #subtypes ),*)
+                ::cqrs::const_concat_slices!(#( #subtypes ),*)
             };
         }
     })

--- a/cqrs-codegen/impl/src/event_sourced.rs
+++ b/cqrs-codegen/impl/src/event_sourced.rs
@@ -1,7 +1,5 @@
 //! Codegen for [`cqrs::EventSourced`].
 
-use std::collections::HashSet;
-
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{punctuated::Punctuated, spanned::Spanned as _, Error, Result};

--- a/cqrs-codegen/impl/src/util.rs
+++ b/cqrs-codegen/impl/src/util.rs
@@ -1,7 +1,5 @@
 //! Common crate utils used for codegen.
 
-use std::collections::HashSet;
-
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{punctuated::Punctuated, spanned::Spanned, Error, Result};

--- a/cqrs-codegen/tests/aggregate_event.rs
+++ b/cqrs-codegen/tests/aggregate_event.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use cqrs::TypedEvent as _;
+use cqrs::{TypedEvent as _, StaticTypedEvent as _};
 use cqrs_codegen::{Aggregate, AggregateEvent, Event};
 
 #[derive(Aggregate, Default)]
@@ -27,11 +27,8 @@ fn derives_for_enum() {
     }
 
     assert_eq!(
-        <TestEvent as cqrs::TypedEvent>::EVENT_TYPES,
-        &[
-            <TestEvent1 as cqrs::StaticTypedEvent>::EVENT_TYPE,
-            <TestEvent2 as cqrs::StaticTypedEvent>::EVENT_TYPE
-        ],
+        TestEvent::EVENT_TYPES,
+        &[TestEvent1::EVENT_TYPE, TestEvent2::EVENT_TYPE],
     );
 }
 
@@ -71,12 +68,12 @@ fn derives_for_generic_enum() {
     type TestEvent = TestEventGeneric<i32, String>;
 
     assert_eq!(
-        <TestEvent as cqrs::TypedEvent>::EVENT_TYPES,
+        TestEvent::EVENT_TYPES,
         &[
-            <TestEvent1 as cqrs::StaticTypedEvent>::EVENT_TYPE,
-            <TestEvent2 as cqrs::StaticTypedEvent>::EVENT_TYPE,
-            <TestEventGeneric1::<i32, String> as cqrs::StaticTypedEvent>::EVENT_TYPE,
-            <TestEventGeneric2::<i32, String> as cqrs::StaticTypedEvent>::EVENT_TYPE,
+            TestEvent1::EVENT_TYPE,
+            TestEvent2::EVENT_TYPE,
+            TestEventGeneric1::<i32, String>::EVENT_TYPE,
+            TestEventGeneric2::<i32, String>::EVENT_TYPE,
         ],
     );
 }

--- a/cqrs-codegen/tests/aggregate_event.rs
+++ b/cqrs-codegen/tests/aggregate_event.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use cqrs::{TypedEvent as _, StaticTypedEvent as _};
+use cqrs::{StaticTypedEvent as _, TypedEvent as _};
 use cqrs_codegen::{Aggregate, AggregateEvent, Event};
 
 #[derive(Aggregate, Default)]

--- a/cqrs-codegen/tests/aggregate_event.rs
+++ b/cqrs-codegen/tests/aggregate_event.rs
@@ -27,8 +27,11 @@ fn derives_for_enum() {
     }
 
     assert_eq!(
-        TestEvent::EVENT_TYPES,
-        &[TestEvent1::EVENT_TYPE, TestEvent2::EVENT_TYPE],
+        <TestEvent as cqrs::TypedEvent>::EVENT_TYPES,
+        &[
+            <TestEvent1 as cqrs::StaticTypedEvent>::EVENT_TYPE,
+            <TestEvent2 as cqrs::StaticTypedEvent>::EVENT_TYPE
+        ],
     );
 }
 
@@ -68,12 +71,12 @@ fn derives_for_generic_enum() {
     type TestEvent = TestEventGeneric<i32, String>;
 
     assert_eq!(
-        TestEvent::EVENT_TYPES,
+        <TestEvent as cqrs::TypedEvent>::EVENT_TYPES,
         &[
-            TestEvent1::EVENT_TYPE,
-            TestEvent2::EVENT_TYPE,
-            TestEventGeneric1::<i32, String>::EVENT_TYPE,
-            TestEventGeneric2::<i32, String>::EVENT_TYPE,
+            <TestEvent1 as cqrs::StaticTypedEvent>::EVENT_TYPE,
+            <TestEvent2 as cqrs::StaticTypedEvent>::EVENT_TYPE,
+            <TestEventGeneric1::<i32, String> as cqrs::StaticTypedEvent>::EVENT_TYPE,
+            <TestEventGeneric2::<i32, String> as cqrs::StaticTypedEvent>::EVENT_TYPE,
         ],
     );
 }

--- a/cqrs-codegen/tests/event.rs
+++ b/cqrs-codegen/tests/event.rs
@@ -5,37 +5,119 @@ use cqrs_codegen::Event;
 
 #[test]
 fn derives_for_struct() {
-    #[derive(Default, Event)]
-    #[event(name = "test.event")]
+    #[derive(
+        Default,
+        // Event
+    )]
+    // #[event(name = "test.event")]
     struct TestEvent {
         id: i32,
         data: String,
     };
 
-    assert_eq!(TestEvent::EVENT_TYPE, "test.event");
+    #[automatically_derived]
+    impl ::cqrs::StaticTypedEvent for TestEvent {
+        #[doc = "Type name of [`TestEvent`] event."]
+        const EVENT_TYPE: ::cqrs::EventType = "test.event";
+    }
+    #[automatically_derived]
+    impl ::cqrs::Event for TestEvent
+    where
+        Self: ::cqrs::StaticTypedEvent,
+    {
+        #[inline(always)]
+        fn event_type(&self) -> ::cqrs::EventType {
+            <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
+        }
+    }
+    #[automatically_derived]
+    impl ::cqrs::TypedEvent for TestEvent
+    where
+        Self: ::cqrs::StaticTypedEvent,
+    {
+        #[doc = "Type names of [`TestEvent`] events."]
+        const EVENT_TYPES: &'static [::cqrs::EventType] =
+            &[<Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE];
+    }
+
+    assert_eq!(
+        <TestEvent as cqrs::StaticTypedEvent>::EVENT_TYPE,
+        "test.event"
+    );
     assert_eq!(TestEvent::default().event_type(), "test.event");
 }
 
 #[test]
 fn derives_for_generic_struct() {
-    #[derive(Default, Event)]
-    #[event(name = "test.event.generic")]
+    #[derive(
+        Default,
+        // Event
+    )]
+    // #[event(name = "test.event.generic")]
     struct TestEventGeneric<ID, Data> {
         id: ID,
         data: Data,
     };
 
+    #[automatically_derived]
+    impl<ID, Data> ::cqrs::StaticTypedEvent for TestEventGeneric<ID, Data> {
+        #[doc = "Type name of [`TestEventGeneric`] event."]
+        const EVENT_TYPE: ::cqrs::EventType = "test.event.generic";
+    }
+    #[automatically_derived]
+    impl<ID, Data> ::cqrs::Event for TestEventGeneric<ID, Data>
+    where
+        Self: ::cqrs::StaticTypedEvent,
+    {
+        #[inline(always)]
+        fn event_type(&self) -> ::cqrs::EventType {
+            <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
+        }
+    }
+    #[automatically_derived]
+    impl<ID, Data> ::cqrs::TypedEvent for TestEventGeneric<ID, Data>
+    where
+        Self: ::cqrs::StaticTypedEvent,
+    {
+        #[doc = "Type names of [`TestEventGeneric`] events."]
+        const EVENT_TYPES: &'static [::cqrs::EventType] =
+            &[<Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE];
+    }
+
     type TestEvent = TestEventGeneric<i32, String>;
 
-    assert_eq!(TestEvent::EVENT_TYPE, "test.event.generic");
+    assert_eq!(
+        <TestEvent as cqrs::StaticTypedEvent>::EVENT_TYPE,
+        "test.event.generic"
+    );
     assert_eq!(TestEvent::default().event_type(), "test.event.generic");
 }
 
 #[test]
 fn derives_for_enum() {
-    #[derive(Default, Event)]
-    #[event(name = "test.event.1")]
+    #[derive(
+        Default,
+        // Event
+    )]
+    // #[event(name = "test.event.1")]
     struct TestEvent1;
+
+    #[automatically_derived] impl :: cqrs :: StaticTypedEvent for TestEvent1
+    {
+        #[doc = "Type name of [`TestEvent1`] event."] const EVENT_TYPE : :: cqrs
+        :: EventType = "test.event.1";
+    } #[automatically_derived] impl :: cqrs :: Event for TestEvent1 where Self :
+    :: cqrs :: StaticTypedEvent
+    {
+        #[inline(always)] fn event_type(& self) -> :: cqrs :: EventType
+        { < Self as :: cqrs :: StaticTypedEvent > :: EVENT_TYPE }
+    } #[automatically_derived] impl :: cqrs :: TypedEvent for TestEvent1 where
+        Self : :: cqrs :: StaticTypedEvent
+    {
+        #[doc = "Type names of [`TestEvent1`] events."] const EVENT_TYPES : &
+        'static [:: cqrs :: EventType] = &
+            [< Self as :: cqrs :: StaticTypedEvent > :: EVENT_TYPE];
+    }
 
     #[derive(Default, Event)]
     #[event(name = "test.event.2")]

--- a/cqrs-codegen/tests/event.rs
+++ b/cqrs-codegen/tests/event.rs
@@ -1,123 +1,41 @@
 #![allow(dead_code)]
 
-use cqrs::Event as _;
+use cqrs::{Event as _, StaticTypedEvent as _};
 use cqrs_codegen::Event;
 
 #[test]
 fn derives_for_struct() {
-    #[derive(
-        Default,
-        // Event
-    )]
-    // #[event(name = "test.event")]
+    #[derive(Default, Event)]
+    #[event(name = "test.event")]
     struct TestEvent {
         id: i32,
         data: String,
     };
 
-    #[automatically_derived]
-    impl ::cqrs::StaticTypedEvent for TestEvent {
-        #[doc = "Type name of [`TestEvent`] event."]
-        const EVENT_TYPE: ::cqrs::EventType = "test.event";
-    }
-    #[automatically_derived]
-    impl ::cqrs::Event for TestEvent
-    where
-        Self: ::cqrs::StaticTypedEvent,
-    {
-        #[inline(always)]
-        fn event_type(&self) -> ::cqrs::EventType {
-            <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
-        }
-    }
-    #[automatically_derived]
-    impl ::cqrs::TypedEvent for TestEvent
-    where
-        Self: ::cqrs::StaticTypedEvent,
-    {
-        #[doc = "Type names of [`TestEvent`] events."]
-        const EVENT_TYPES: &'static [::cqrs::EventType] =
-            &[<Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE];
-    }
-
-    assert_eq!(
-        <TestEvent as cqrs::StaticTypedEvent>::EVENT_TYPE,
-        "test.event"
-    );
+    assert_eq!(TestEvent::EVENT_TYPE, "test.event");
     assert_eq!(TestEvent::default().event_type(), "test.event");
 }
 
 #[test]
 fn derives_for_generic_struct() {
-    #[derive(
-        Default,
-        // Event
-    )]
-    // #[event(name = "test.event.generic")]
+    #[derive(Default, Event)]
+    #[event(name = "test.event.generic")]
     struct TestEventGeneric<ID, Data> {
         id: ID,
         data: Data,
     };
 
-    #[automatically_derived]
-    impl<ID, Data> ::cqrs::StaticTypedEvent for TestEventGeneric<ID, Data> {
-        #[doc = "Type name of [`TestEventGeneric`] event."]
-        const EVENT_TYPE: ::cqrs::EventType = "test.event.generic";
-    }
-    #[automatically_derived]
-    impl<ID, Data> ::cqrs::Event for TestEventGeneric<ID, Data>
-    where
-        Self: ::cqrs::StaticTypedEvent,
-    {
-        #[inline(always)]
-        fn event_type(&self) -> ::cqrs::EventType {
-            <Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE
-        }
-    }
-    #[automatically_derived]
-    impl<ID, Data> ::cqrs::TypedEvent for TestEventGeneric<ID, Data>
-    where
-        Self: ::cqrs::StaticTypedEvent,
-    {
-        #[doc = "Type names of [`TestEventGeneric`] events."]
-        const EVENT_TYPES: &'static [::cqrs::EventType] =
-            &[<Self as ::cqrs::StaticTypedEvent>::EVENT_TYPE];
-    }
-
     type TestEvent = TestEventGeneric<i32, String>;
 
-    assert_eq!(
-        <TestEvent as cqrs::StaticTypedEvent>::EVENT_TYPE,
-        "test.event.generic"
-    );
+    assert_eq!(TestEvent::EVENT_TYPE, "test.event.generic");
     assert_eq!(TestEvent::default().event_type(), "test.event.generic");
 }
 
 #[test]
 fn derives_for_enum() {
-    #[derive(
-        Default,
-        // Event
-    )]
-    // #[event(name = "test.event.1")]
+    #[derive(Default, Event)]
+    #[event(name = "test.event.1")]
     struct TestEvent1;
-
-    #[automatically_derived] impl :: cqrs :: StaticTypedEvent for TestEvent1
-    {
-        #[doc = "Type name of [`TestEvent1`] event."] const EVENT_TYPE : :: cqrs
-        :: EventType = "test.event.1";
-    } #[automatically_derived] impl :: cqrs :: Event for TestEvent1 where Self :
-    :: cqrs :: StaticTypedEvent
-    {
-        #[inline(always)] fn event_type(& self) -> :: cqrs :: EventType
-        { < Self as :: cqrs :: StaticTypedEvent > :: EVENT_TYPE }
-    } #[automatically_derived] impl :: cqrs :: TypedEvent for TestEvent1 where
-        Self : :: cqrs :: StaticTypedEvent
-    {
-        #[doc = "Type names of [`TestEvent1`] events."] const EVENT_TYPES : &
-        'static [:: cqrs :: EventType] = &
-            [< Self as :: cqrs :: StaticTypedEvent > :: EVENT_TYPE];
-    }
 
     #[derive(Default, Event)]
     #[event(name = "test.event.2")]

--- a/cqrs-core/src/event.rs
+++ b/cqrs-core/src/event.rs
@@ -28,6 +28,12 @@ pub trait Event {
     fn event_type(&self) -> EventType;
 }
 
+/// [`Event`] with a statically known [`EventType`].
+pub trait StaticTypedEvent {
+    /// Type of this [`Event`].
+    const EVENT_TYPE: EventType;
+}
+
 /// State that can be calculated by applying specified [`Event`].
 ///
 /// Usually, implemented by an [`Aggregate`].

--- a/cqrs-core/src/event.rs
+++ b/cqrs-core/src/event.rs
@@ -28,12 +28,6 @@ pub trait Event {
     fn event_type(&self) -> EventType;
 }
 
-/// [`Event`] with a statically known [`EventType`].
-pub trait StaticTypedEvent {
-    /// Type of this [`Event`].
-    const EVENT_TYPE: EventType;
-}
-
 /// State that can be calculated by applying specified [`Event`].
 ///
 /// Usually, implemented by an [`Aggregate`].
@@ -46,6 +40,12 @@ pub trait EventSourced<Ev: ?Sized> {
 pub trait TypedEvent {
     /// All available types of this [`Event`].
     const EVENT_TYPES: &'static [EventType];
+}
+
+/// [`TypedEvent`] with a statically known [`EventType`].
+pub trait StaticTypedEvent {
+    /// Type of this [`Event`].
+    const EVENT_TYPE: EventType;
 }
 
 /// Different version of [`Event`] with the same [`EventType`].

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($ty:ty, $a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 255;
+                const __LEN: usize = 32;
                 let mut out = [""; __LEN];
                 let mut i = 0;
                 while i < $a.len() {

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 255;
+                const __LEN: usize = 512;
                 if $a.len() + $b.len() > __LEN {
                     compile_error!("concatenated slices exceed maximum length");
                 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,9 +46,9 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 4080;
+                const __LEN: usize = 255;
                 if $a.len() + $b.len() > __LEN {
-                    compile_error!("concatenated slices exceed maximum length");
+                    panic!("concatenated slices exceed maximum length");
                 }
 
                 let mut out = [""; __LEN];

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -47,7 +47,7 @@ pub mod private {
         at: usize,
     ) -> &'static [&'static str] {
         if at > N {
-            panic!("index out of bounds: {} > {}", at, N);
+            panic!("index out of bounds");
         }
         #[allow(unsafe_code, reason = "macro internals")]
         unsafe {

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 32;
+                const __LEN: usize = 255;
                 if $a.len() + $b.len() > __LEN {
                     compile_error!("concatenated slices exceed maximum length");
                 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! const_concat_slices {
     ($a:expr, $b:expr $(,)*) => {
         $crate::private::slice_arr(
             &const {
-                const __LEN: usize = 512;
+                const __LEN: usize = 4080;
                 if $a.len() + $b.len() > __LEN {
                     compile_error!("concatenated slices exceed maximum length");
                 }

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -47,7 +47,7 @@ pub mod private {
         at: usize,
     ) -> &'static [&'static str] {
         if at > N {
-            panic!("index out of bounds: {at} > {N}");
+            panic!("index out of bounds: {} > {}", at, N);
         }
         #[allow(unsafe_code, reason = "macro internals")]
         unsafe {

--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -39,42 +39,6 @@ pub use self::{aggregate::*, command::*, event::*};
 /// Helper alias for pin-boxed `?Send` [`Stream`] which yields [`Result`]s.
 pub type LocalBoxTryStream<'a, I, E> = Pin<Box<dyn Stream<Item = Result<I, E>> + 'a>>;
 
-/// Concatenates slices at compile time.
-#[macro_export]
-macro_rules! const_concat_slices {
-    ($a:expr) => {$a};
-    ($a:expr, $b:expr $(,)*) => {
-        $crate::private::slice_arr(
-            &const {
-                const __LEN: usize = 255;
-                if $a.len() + $b.len() > __LEN {
-                    panic!("concatenated slices exceed maximum length");
-                }
-
-                let mut out = [""; __LEN];
-                let mut i = 0;
-                while i < $a.len() {
-                    out[i] = $a[i];
-                    i += 1;
-                }
-                i = 0;
-                while i < $b.len() {
-                    out[i + $a.len()] = $b[i];
-                    i += 1;
-                }
-                out
-            },
-            $a.len() + $b.len(),
-        )
-    };
-    ($a:expr, $b:expr, $($c:expr),+ $(,)*) => {
-        $crate::const_concat_slices!(
-            $a,
-            $crate::const_concat_slices!($b, $($c),+)
-        )
-    };
-}
-
 #[doc(hidden)]
 pub mod private {
     /// Slices an array of strings at compile time.


### PR DESCRIPTION
`#[derive(cqrs::Event)]` expands with:
```rust
impl MyStruct {
    pub const EVENT_TYPE: cqrs::EventType = "...";
}
```

which cannot be used in generic contexts.

The solution is to add `StaticTypedEvent` trait containing this `EVENT_TYPE` constant.