### PR TITLE
Increase `cqrs::TypedEvent::EVENT_TYPES` limit to 512

### DIFF
--- a/cqrs-codegen/impl/src/event/event.rs
+++ b/cqrs-codegen/impl/src/event/event.rs
@@ -196,7 +196,7 @@ mod spec {
                 const EVENT_TYPES: &'static [::cqrs::EventType] = {
                     ::cqrs::private::slice_arr(
                         &const {
-                            const __LEN: usize = 256;
+                            const __LEN: usize = 512;
                             if 0
                                 + <Event1 as ::cqrs::TypedEvent>::EVENT_TYPES
                                      .len()

--- a/cqrs-codegen/impl/src/event/typed_event.rs
+++ b/cqrs-codegen/impl/src/event/typed_event.rs
@@ -123,10 +123,10 @@ fn derive_enum(input: syn::DeriveInput) -> Result<TokenStream> {
             const EVENT_TYPES: &'static [::cqrs::EventType] =
                 ::cqrs::private::slice_arr(
                     &const {
-                        const __LEN: usize = 256;
+                        const __LEN: usize = 512;
                         if #len > __LEN {
                             panic!("`cqrs::TypedEvent::EVENT_TYPES` limit \
-                                    reached: 256");
+                                    reached: 512");
                         }
 
                         let mut out = [""; __LEN];


### PR DESCRIPTION
PR bumps recursion limit.